### PR TITLE
github: workflows: Add manifest workflow

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -1,0 +1,39 @@
+name: Manifest
+on:
+  pull_request_target
+
+permissions:
+  contents: read
+
+jobs:
+  manifest:
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+    name: Manifest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: zephyr-silabs
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: west setup
+        working-directory: zephyr-silabs
+        run: |
+          pip install west
+          west init -l .
+          west update zephyr
+
+      - name: Manifest
+        uses: zephyrproject-rtos/action-manifest@09983f53d3d878791aa37a7755ae44d695f4c1e5 #2.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          manifest-path: 'west.yml'
+          checkout-path: 'zephyr-silabs'
+          use-tree-checkout: 'true'
+          check-impostor-commits: 'true'
+          verbosity-level: '1'
+          labels: 'manifest'
+          dnm-labels: 'DNM (manifest)'


### PR DESCRIPTION
Add a manifest workflow to detect when a pull request is referencing a west module pull request through the west manifest.